### PR TITLE
5533 - B032 - AUMENTAR ÁREA DE CLIQUE PARA A CRIAÇÃO DE NOVO DOCUMENTO

### DIFF
--- a/lib/components/z-selection/z-selection-list.dart
+++ b/lib/components/z-selection/z-selection-list.dart
@@ -131,12 +131,7 @@ class ZSelectionListState extends State<ZSelectionList> {
               widget.onAdd();
             },
             leading: new Text(widget.textoOnAdd),
-            trailing: new IconButton(
-                icon: Icon(
-                  Icons.add,
-                  color: widget.theme.primaryColor,
-                ),
-                onPressed: () {}),
+            trailing: new Icon(Icons.add, color: widget.theme.primaryColor)
           ),
           new Divider(
             height: 1,


### PR DESCRIPTION
Foi necessário aumentar a área do clique, pois foi adicionado um IconButton dentro de um ZTile,  ao invés de somente um Icon mesmo, anulando o onTap do ZTile quando o usuário clicava em cima do icone. 

Removido e já testado referenciando minha versão do Zcomponents.